### PR TITLE
Bugfix: make const confirmPassword store the value of input field confirm-new-password instead of new-password

### DIFF
--- a/scripts/index.mjs
+++ b/scripts/index.mjs
@@ -10,7 +10,7 @@ function updatePasswordDialog() {
 				label: game.i18n.localize('update-your-password.dialog.buttons.apply.label'),
 				callback: async (html) => {
 					const newPassword = html.find('#new-password')[0].value;
-					const confirmPassword = html.find('#new-password')[0].value;
+					const confirmPassword = html.find('#confirm-new-password')[0].value;
 					if (newPassword !== confirmPassword) {
 						ui.notifications.error('update-your-password.notifications.error.confirm-not-match', { localize: true });
 						return;


### PR DESCRIPTION
The callback script compared the value of new-password with itself instead of comparing it to confirm-new-password.
This pull request fixes that bug by reading confirm-new-password into the const confirmPassword.